### PR TITLE
Add support for retrieving specific versions of secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/cyberark/summon-aws-secrets
 require (
 	github.com/aws/aws-sdk-go v1.34.20
 	github.com/smartystreets/goconvey v1.6.4
-	github.com/stretchr/testify v1.5.1 // indirect
 )
 
 go 1.13


### PR DESCRIPTION
### What does this PR do?

* Provides the ability for users to specify a secret version to retrieve.
* A path such as: `!var accounting/database#username^AWSPREVIOUS` will now fetch the `username` key with the version ID of `AWSPREVIOUS`

#### Context

* AWS has the ability to specify [versions / staging labels](https://docs.aws.amazon.com/secretsmanager/latest/userguide/terms-concepts.html#term_staging-label) for secrets.
* By default, the newest version will take on the label `AWSCURRENT`
* When an AWS SecretsManager executes a `update-secret` operation, it assigns the version `AWSCURRENT` to the new value, and `AWSPREVIOUS` to the one before it.
* When Summon fetches a secret from AWS Secrets Manager, it retrieves the `AWSCURRENT` by default.
* This feature comes in handy if users want to specify specific versions (i.e. when doing a credential rotation)
* This provider already specifies a way to get a specific `key` from a secret (if stored as a JSON object) by using the `#` separator. 
     * i.e. If we have a secret such as `accounting/database` that looks like: `{"username":"bob","password":"changeme"}`, using a path like `!var accounting/database#username` will return `bob`
* Using the same precedent, we will return specific versions using the `^` operator (i.e. `!var accounting/database#username^AWSPREVIOUS`

### What ticket does this PR close?
* I need to create a ticket

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
* I have no idea how to test this  ¯\_(ツ)_/¯ 
* Manual tests:

|        | `!var accounting/database#username` | `!var accounting/database#password`|          
| ------------- |:-------------:| -----:|
| `AWSPREVIOUS`      | username_a | password0 |
| `AWSCURRENT`      | username_b      |   password1 |

1. Retrieve specific key and version
```
go run main.go accounting/database#username^AWSPREVIOUS                                                                                                                                                                                                        
username_a%    
```

2. Retrieve specific key and current version
```                                                                                                                                                                                                                                                                                                                                                                                                              
 go run main.go accounting/database#username^AWSCURRENT                                                                                                                                                                                                       
username_b%
```

3. Show that retrieving specific key without specific version returns current version
```                                                                                                                                                                                                                                                                                                                                                                                                                  
 go run main.go accounting/database#username                                                                                                                                                                                                                   
username_b%
```

4. Retrieve whole secret with specified current version
```                                                                                                                                                                                                                                                                                                                                                                                                                  
 go run main.go accounting/database^AWSCURRENT                                                                                                                                                                                                                 
{"username":"username_b","password":"password1"}%
```

5. Retrieve whole secret with specific version
```                                                                                                                                                                                                                                                                                                                                                                            
go run main.go accounting/database^AWSPREVIOUS                                                                                                                                                                                                               
{"username":"username_a","password":"password0"}%    
```

6. Attempt to get a secret with a version that doesn't exist

```
go run main.go accounting/database^DOESNTEXIST                                                                                                                                                                                                              
ResourceNotFoundException: Secrets Manager can't find the specified secret value for staging label: DOESNTEXISTexit status 1
```


#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
